### PR TITLE
Add media query

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -44,3 +44,7 @@ table tbody tr td a
 
 .sidebar .sidebar-links li div .sidebar-heading:hover
 	color #f4645f
+
+@media screen and (min-width: 720px) and (max-width: 1024px)
+	.nav-links
+		display: none !important;


### PR DESCRIPTION
### Navbar Links
Para los breakpoints entre 720px y 1204px el navbar no es responsivo.
Agregue el media query para ocultar el `.nav-links` solo en esos breakpoints.